### PR TITLE
feat: upgrade to ESLint v7, standard-with-typescript v18

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.printReport = exports.lintFiles = exports.lintStdIn = exports.cli = exports.ESLINT_BUILTIN_REPORTERS = void 0;
 const getStdin = require("get-stdin");
 const options_1 = require("./options");
 const ts_standard_1 = require("./ts-standard");

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,16 @@
 "use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 // Export the real API usage class
-__export(require("./ts-standard"));
+__exportStar(require("./ts-standard"), exports);
 // Export standard-engine compatible api for so that editor extensions work as expected
-__export(require("./standard-engine-api"));
+__exportStar(require("./standard-engine-api"), exports);

--- a/dist/options/cli-options.js
+++ b/dist/options/cli-options.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports._convertToArray = exports.getCLIOptions = exports.TAGLINE = exports.CMD = void 0;
 const minimist = require("minimist");
 exports.CMD = 'ts-standard';
 exports.TAGLINE = 'Typescript Standard Style!';

--- a/dist/options/default-options.js
+++ b/dist/options/default-options.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports._isValidPath = exports._getTSConfigFromDefaultLocations = exports.getDefaultOptions = exports.DEFAULT_TSCONFIG_LOCATIONS = void 0;
 const path_1 = require("path");
 const fs_1 = require("fs");
 exports.DEFAULT_TSCONFIG_LOCATIONS = [

--- a/dist/options/index.js
+++ b/dist/options/index.js
@@ -1,11 +1,19 @@
 "use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(require("./default-options"));
-__export(require("./cli-options"));
-__export(require("./package-options"));
+exports.mergeOptions = void 0;
+__exportStar(require("./default-options"), exports);
+__exportStar(require("./cli-options"), exports);
+__exportStar(require("./package-options"), exports);
 // A simple utility function to merge objects together ignoring any undefined values
 function mergeOptions(...objects) {
     var _a;

--- a/dist/options/package-options.js
+++ b/dist/options/package-options.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports._resolveTSConfigPath = exports.getPackageOptions = void 0;
 const path_1 = require("path");
 const pkg_conf_1 = require("pkg-conf");
 const default_options_1 = require("./default-options");

--- a/dist/standard-engine-api.js
+++ b/dist/standard-engine-api.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.lintFiles = exports.lintText = exports.parseOpts = void 0;
 const ts_standard_1 = require("./ts-standard");
 // All exports are to satisfy the `standard-engine` export interface used by
 // the vscode standard extension and other editor extensions

--- a/dist/standard-reporter.js
+++ b/dist/standard-reporter.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.standardReporter = void 0;
 function standardReporter(isUsingStdInAndFix) {
     return (lintResults) => {
         const prefix = isUsingStdInAndFix ? 'ts-standard:' : ' ';

--- a/dist/ts-standard.js
+++ b/dist/ts-standard.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.TSStandard = void 0;
 const eslint = require("eslint");
 const path_1 = require("path");
 const standard_engine_1 = require("standard-engine");

--- a/package.json
+++ b/package.json
@@ -18,43 +18,43 @@
     "url": "https://github.com/toddbluhm/ts-standard/issues"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Todd Bluhm",
   "license": "MIT",
   "homepage": "https://github.com/toddbluhm/ts-standard",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.29.0",
-    "eslint": "^6.0.0",
-    "eslint-config-standard": "^14.0.0",
-    "eslint-config-standard-jsx": "^8.0.0",
-    "eslint-config-standard-with-typescript": "^16.0.0",
-    "eslint-plugin-import": "^2.18.0",
-    "eslint-plugin-node": "^11.0.0",
+    "@typescript-eslint/eslint-plugin": "^3.0.2",
+    "eslint": "^7.1.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-config-standard-jsx": "^8.1.0",
+    "eslint-config-standard-with-typescript": "^18.0.2",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "^7.0.0",
-    "eslint-plugin-standard": "^4.0.0",
-    "get-stdin": "^7.0.0",
-    "minimist": "^1.0.0",
-    "pkg-conf": "^3.0.0",
-    "standard-engine": "^12.0.0"
+    "eslint-plugin-react": "^7.20.0",
+    "eslint-plugin-standard": "^4.0.1",
+    "get-stdin": "^8.0.0",
+    "minimist": "^1.2.5",
+    "pkg-conf": "^3.1.0",
+    "standard-engine": "^12.1.0"
   },
   "peerDependencies": {
-    "typescript": ">=3.8"
+    "typescript": ">=3.9"
   },
   "devDependencies": {
-    "@commitlint/cli": "^8.0.0",
-    "@commitlint/config-conventional": "^8.0.0",
-    "@types/eslint": "^6.0.0",
-    "@types/jest": "^25.2.1",
-    "@types/minimist": "^1.0.0",
-    "@types/node": "^12.0.0",
-    "coveralls": "^3.0.0",
-    "husky": "^4.0.0",
-    "jest": "^25.4.0",
-    "ts-jest": "^25.4.0",
-    "ts-node": "^8.0.0",
-    "typescript": "^3.8.3"
+    "@commitlint/cli": "^8.3.5",
+    "@commitlint/config-conventional": "^8.3.4",
+    "@types/eslint": "^6.8.1",
+    "@types/jest": "^25.2.3",
+    "@types/minimist": "^1.2.0",
+    "@types/node": "^14.0.5",
+    "coveralls": "^3.1.0",
+    "husky": "^4.2.5",
+    "jest": "^26.0.1",
+    "ts-jest": "^26.0.0",
+    "ts-node": "^8.10.1",
+    "typescript": "^3.9.3"
   },
   "keywords": [
     "Typescript Standard Style",


### PR DESCRIPTION
This pulls in some new rules, upgraded peer-dependencies, and drops support for Node.js 8.x, so it's a breaking change